### PR TITLE
Remove pywallet and replace with pycoin for bip32

### DIFF
--- a/binance_chain/wallet.py
+++ b/binance_chain/wallet.py
@@ -4,7 +4,7 @@ from typing import Optional
 
 from secp256k1 import PrivateKey
 from mnemonic import Mnemonic
-from pywallet.utils.bip32 import Wallet as Bip32Wallet
+from pycoin.symbols.btc import network
 
 from binance_chain.utils.segwit_addr import address_from_public_key, decode_address
 from binance_chain.environment import BinanceEnvironment
@@ -131,9 +131,11 @@ class Wallet(BaseWallet):
         :return:
         """
         seed = Mnemonic.to_seed(mnemonic)
-        new_wallet = Bip32Wallet.from_master_secret(seed=seed, network='BTC')
-        child = new_wallet.get_child_for_path(Wallet.HD_PATH)
-        return cls(child.get_private_key_hex().decode(), env=env)
+        parent_wallet = network.keys.bip32_seed(seed)
+        child_wallet = parent_wallet.subkey_for_path(Wallet.HD_PATH)
+        # convert secret exponent (private key) int to hex
+        key_hex = format(child_wallet.secret_exponent(), 'x')
+        return cls(key_hex, env=env)
 
     @property
     def private_key(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pywallet>=0.1.0
+pycoin>=0.90.20190630
 requests>=2.21.0
 aiohttp>=3.5.4
 websockets>=7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pycoin>=0.90.20190630
+pycoin>=0.90.20201031
 requests>=2.21.0
 aiohttp>=3.5.4
 websockets>=7.0

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ def find_version(*file_paths):
 def install_requires():
 
     requires = [
-        'pywallet>=0.1.0', 'requests>=2.21.0', 'websockets>=7.0', 'aiohttp>=3.5.4',
+        'pycoin>=0.90.20190630', 'requests>=2.21.0', 'websockets>=7.0', 'aiohttp>=3.5.4',
         'secp256k1>=0.13.2', 'protobuf>=3.6.1', 'mnemonic>=0.18', 'ujson>=1.35'
     ]
     return requires

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ def find_version(*file_paths):
 def install_requires():
 
     requires = [
-        'pycoin>=0.90.20190630', 'requests>=2.21.0', 'websockets>=7.0', 'aiohttp>=3.5.4',
+        'pycoin>=0.90.20201031', 'requests>=2.21.0', 'websockets>=7.0', 'aiohttp>=3.5.4',
         'secp256k1>=0.13.2', 'protobuf>=3.6.1', 'mnemonic>=0.18', 'ujson>=1.35'
     ]
     return requires


### PR DESCRIPTION
Fixes #29 

pywallet brings in a ridiculous amount of (strict) dependencies, and is only used for bip32 wallet generation.

I've replaced this with [pycoin](https://github.com/richardkiss/pycoin) which doesn't carry any extra dependencies with it for bip32 wallet generation.

Before:
![image](https://user-images.githubusercontent.com/11189778/66367084-383c3180-e982-11e9-814e-6d796cee805e.png)
(~81MB of required dependencies)

After:
![image](https://user-images.githubusercontent.com/11189778/66367097-4be79800-e982-11e9-82b8-c2ca82b34e45.png)
(~36MB of required dependencies)