### PR TITLE
set limit to 1000 of get_markets

### DIFF
--- a/binance_chain/http.py
+++ b/binance_chain/http.py
@@ -289,7 +289,7 @@ class HttpApiClient(BaseApiClient):
         :return: API Response
 
         """
-        return self._get("markets")
+        return self._get("markets?limit=1000")
 
     def get_fees(self):
         """Gets the current trading fees settings


### PR DESCRIPTION
The default limit for `get_markets` is 100 (despite the docs saying 500). Since there are 140+ BEP2 assets, the `get_markets` function doesn't return all markets. This change sets the query to have a limit of `1000`.