### PR TITLE
Round float

### DIFF
--- a/binance_chain/http.py
+++ b/binance_chain/http.py
@@ -289,7 +289,7 @@ class HttpApiClient(BaseApiClient):
         :return: API Response
 
         """
-        return self._get("markets")
+        return self._get("markets?limit=1000")
 
     def get_fees(self):
         """Gets the current trading fees settings

--- a/binance_chain/utils/encode_utils.py
+++ b/binance_chain/utils/encode_utils.py
@@ -12,7 +12,7 @@ def encode_number(num: Union[float, Decimal]) -> int:
     if type(num) == Decimal:
         return int(num * (Decimal(10) ** 8))
     else:
-        return int(num * math.pow(10, 8))
+        return int(round(num * 1e8))
 
 
 def varint_encode(num):


### PR DESCRIPTION
Found the current code doesn't work. Example...

```
int(0.0313013 * math.pow(10, 8)) == 3130129

0.0313013 * 1e8 == 3130129.9999999995
```