### PR TITLE
Fixed versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
 pycoin>=0.90.20201031
-requests>=2.21.0
+requests>=2.11.0
 aiohttp>=3.5.4
 websockets>=7.0
 secp256k1>=0.13.2
 mnemonic>=0.18
 protobuf>=3.6.1
+ujson>=5.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ websockets>=7.0
 secp256k1>=0.13.2
 mnemonic>=0.18
 protobuf>=3.6.1
-ujson>=5.0.0
+ujson>=1.35

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ def find_version(*file_paths):
 def install_requires():
 
     requires = [
-        'pycoin>=0.90.20201031', 'requests>=2.21.0', 'websockets>=7.0', 'aiohttp>=3.5.4',
+        'pycoin>=0.90.20201031', 'requests>=2.11.0', 'websockets>=7.0', 'aiohttp>=3.5.4',
         'secp256k1>=0.13.2', 'protobuf>=3.6.1', 'mnemonic>=0.18', 'ujson>=1.35'
     ]
     return requires


### PR DESCRIPTION
Updated versions to fix poetry issue
```
  SolverProblemError

  Because no versions of two1 match >3.10.8,<3.10.9 || >3.10.9
   and two1 (3.10.8) depends on requests (<=2.11.1), two1 (>=3.10.8,<3.10.9 || >3.10.9) requires requests (<=2.11.1).
  And because two1 (3.10.9) depends on requests (<=2.11.1), two1 (>=3.10.8) requires requests (<=2.11.1).
  Because no versions of pywallet match >0.1.0
   and pywallet (0.1.0) depends on two1 (>=3.10.8), pywallet (>=0.1.0) requires two1 (>=3.10.8).
  Thus, pywallet (>=0.1.0) requires requests (<=2.11.1).
  And because python-binance-chain (0.1.20) depends on both pywallet (>=0.1.0) and requests (>=2.21.0), python-binance-chain is forbidden.
  So, because no versions of python-binance-chain match >0.1.20,<0.2.0
   and test depends on python-binance-chain (^0.1.20), version solving failed.

  at ~/.poetry/lib/poetry/puzzle/solver.py:241 in _solve
      237│             packages = result.packages
      238│         except OverrideNeeded as e:
      239│             return self.solve_in_compatibility_mode(e.overrides, use_latest=use_latest)
      240│         except SolveFailure as e:
    → 241│             raise SolverProblemError(e)
      242│ 
      243│         results = dict(
      244│             depth_first_search(
      245│                 PackageNode(self._package, packages), aggregate_package_nodes
```